### PR TITLE
Move call to root() into main.dart

### DIFF
--- a/step_6/lib/chat.dart
+++ b/step_6/lib/chat.dart
@@ -40,7 +40,7 @@ class ChatScreenState extends State<ChatScreen> {
   void initState() {
     _currentMessage = InputValue.empty;
     _messages = <Map<String, String>>[];
-    _onChildAdded = config.firebase.root().onChildAdded.listen((Event event) {
+    _onChildAdded = config.firebase.onChildAdded.listen((Event event) {
       setState(() => _messages.add(event.snapshot.val()));
     });
     super.initState();

--- a/step_6/lib/main.dart
+++ b/step_6/lib/main.dart
@@ -40,7 +40,7 @@ class FirechatAppState extends State {
       routes: <String, RouteBuilder>{
         '/': (RouteArguments args) => new ChatScreen(
           fontSize: _fontSize,
-          firebase: _firebase,
+          firebase: _firebase.root(),
           user: _user
         ),
         '/settings': (RouteArguments args) => new SettingsScreen(


### PR DESCRIPTION
This is more consistent with where I think things would go in future steps, you pass child Firebase nodes to widgets and they would avoid going up the tree in most cases.